### PR TITLE
Add append option to deploy script

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,7 +43,7 @@
   "scripts": {
     "build": "gatsby build",
     "develop": "gatsby develop",
-    "deploy": "gatsby build && gh-pages -d public -b master -r https://github.com/openclimatefix/openclimatefix.github.io",
+    "deploy": "gatsby build && gh-pages -d public -b master -r https://github.com/openclimatefix/openclimatefix.github.io -a",
     "format": "prettier --write \"**/*.{js,jsx,json,md}\"",
     "lint": "eslint . --ext .js,.jsx",
     "start": "npm run develop",


### PR DESCRIPTION
We are for now simply changing the deployment to append-only as there is no other quick fix.
This will likely produce a lot of garbage files in the destination repo.

We will revisit this however anyways fairly soon via #7 so the tradeoff is negligible for the time being.

Fixes #15.