### PR TITLE
Add link to previous/next blog post

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -5,12 +5,12 @@
  */
 
 // You can delete this file if you're not using it
-const path = require('path');
+const dirPath = require('path');
 
 exports.createPages = async ({ actions, graphql, reporter }) => {
   const { createPage } = actions;
 
-  const blogPostTemplate = path.resolve('src/components/BlogPost/BlogPost.jsx');
+  const blogPostTemplate = dirPath.resolve('src/components/BlogPost/BlogPost.jsx');
 
   const result = await graphql(`
     {
@@ -34,12 +34,16 @@ exports.createPages = async ({ actions, graphql, reporter }) => {
     reporter.panicOnBuild('Error while running GraphQL query.');
     return;
   }
-
-  result.data.allMarkdownRemark.edges.forEach(({ node }) => {
+  const posts = result.data.allMarkdownRemark.edges;
+  result.data.allMarkdownRemark.edges.forEach(({ node }, index) => {
+    const { path } = node.frontmatter;
     createPage({
-      path: node.frontmatter.path,
+      path,
       component: blogPostTemplate,
-      context: {}, // additional data can be passed via context
+      context: {
+        prev: index === 0 ? null : posts[index - 1].node,
+        next: index === (posts.length - 1) ? null : posts[index + 1].node,
+      },
     });
   });
 };

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -35,7 +35,7 @@ exports.createPages = async ({ actions, graphql, reporter }) => {
     return;
   }
   const posts = result.data.allMarkdownRemark.edges;
-  result.data.allMarkdownRemark.edges.forEach(({ node }, index) => {
+  posts.forEach(({ node }, index) => {
     const { path } = node.frontmatter;
     createPage({
       path,

--- a/src/components/BlogPost/BlogPost.jsx
+++ b/src/components/BlogPost/BlogPost.jsx
@@ -7,11 +7,13 @@ import SEO from '../seo';
 import Layout from '../Layout';
 
 import AuthorInline from './AuthorInline';
-
+import PostNavigation from './PostNavigation';
 
 export default function BlogPost({
   data, // this prop will be injected by the GraphQL query below.
+  pageContext,
 }) {
+  const { prev, next } = pageContext;
   const { markdownRemark: { frontmatter, html } } = data;
   const {
     authorName,
@@ -32,6 +34,7 @@ export default function BlogPost({
         </p>
         <div className="markdown" dangerouslySetInnerHTML={{ __html: html }} />
       </article>
+      <PostNavigation prev={prev} next={next} />
     </Layout>
   );
 }
@@ -61,6 +64,18 @@ BlogPost.propTypes = {
         title: PropTypes.string.isRequired,
         authorName: PropTypes.string.isRequired,
         authorTwitter: PropTypes.string,
+      }).isRequired,
+    }).isRequired,
+  }).isRequired,
+  pageContext: PropTypes.shape({
+    prev: PropTypes.shape({
+      frontmatter: PropTypes.shape({
+        path: PropTypes.string.isRequired,
+      }).isRequired,
+    }).isRequired,
+    next: PropTypes.shape({
+      frontmatter: PropTypes.shape({
+        path: PropTypes.string.isRequired,
       }).isRequired,
     }).isRequired,
   }).isRequired,

--- a/src/components/BlogPost/PostNavigation.jsx
+++ b/src/components/BlogPost/PostNavigation.jsx
@@ -1,0 +1,45 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Link } from 'gatsby';
+
+import { FaCaretLeft, FaCaretRight } from 'react-icons/fa';
+
+const PostNavigation = ({ prev, next }) => (
+  <div className="flex justify-center h-24">
+    { prev
+          && (
+            <Link to={prev.frontmatter.path}>
+              <div className="flex-1 text-center px-4 py-2 m-2">
+                <FaCaretLeft size="20" className="inline mr-0" />
+          Next
+              </div>
+            </Link>
+          )}
+    { next
+          && (
+            <Link to={next.frontmatter.path}>
+              <div className="flex-1 text-center px-4 py-2 m-2">
+Previous
+                <FaCaretRight size="20" className="inline mr-0" />
+              </div>
+            </Link>
+          )}
+
+  </div>
+
+);
+
+PostNavigation.propTypes = {
+  prev: PropTypes.shape({
+    frontmatter: PropTypes.shape({
+      path: PropTypes.string.isRequired,
+    }).isRequired,
+  }).isRequired,
+  next: PropTypes.shape({
+    frontmatter: PropTypes.shape({
+      path: PropTypes.string.isRequired,
+    }).isRequired,
+  }).isRequired,
+};
+
+export default PostNavigation;

--- a/src/components/BlogPost/PostNavigation.jsx
+++ b/src/components/BlogPost/PostNavigation.jsx
@@ -11,7 +11,7 @@ const PostNavigation = ({ prev, next }) => (
             <Link to={prev.frontmatter.path}>
               <div className="flex-1 text-center px-4 py-2 m-2">
                 <FaCaretLeft size="20" className="inline mr-0" />
-          Next
+                Next
               </div>
             </Link>
           )}
@@ -19,14 +19,12 @@ const PostNavigation = ({ prev, next }) => (
           && (
             <Link to={next.frontmatter.path}>
               <div className="flex-1 text-center px-4 py-2 m-2">
-Previous
+                Previous
                 <FaCaretRight size="20" className="inline mr-0" />
               </div>
             </Link>
           )}
-
   </div>
-
 );
 
 PostNavigation.propTypes = {

--- a/src/components/BlogPost/PostNavigation.jsx
+++ b/src/components/BlogPost/PostNavigation.jsx
@@ -9,7 +9,7 @@ const PostNavigation = ({ prev, next }) => (
     { prev
           && (
             <Link to={prev.frontmatter.path}>
-              <div className="flex-1 text-center px-4 py-2 m-2">
+              <div className="flex-center items-center px-4 py-2 m-2">
                 <FaCaretLeft size="20" className="inline mr-0" />
                 Next
               </div>
@@ -18,7 +18,7 @@ const PostNavigation = ({ prev, next }) => (
     { next
           && (
             <Link to={next.frontmatter.path}>
-              <div className="flex-1 text-center px-4 py-2 m-2">
+              <div className="flex-center items-center px-4 py-2 m-2">
                 Previous
                 <FaCaretRight size="20" className="inline mr-0" />
               </div>


### PR DESCRIPTION
**What changes were made?**
1. gatsby-node.js: Added pathSlug, prev, next keys to context object for createPage.
2. src/components/BlogPost/blogpost.jsx: Add jsx code for prev-next with icons.

**Why were these changes made?**
Fix #6 to provide links to previous and next blogposts

**Lint Test**
There is a current error for eslint in [gatsby-node.js](https://github.com/sukhbeersingh/website/blob/f4d3cf8691347a9a1dcefa8d10522b030df4b21e/gatsby-node.js#L8) as this name conflicts with `path` variable deconstructed from `node.frontmatter`. We should possibly change the former variable name.

**Visual**
![prev_next](https://user-images.githubusercontent.com/44414281/67640570-aadd6480-f8d1-11e9-85e8-7db2c896c5c1.png)

**Suggestion**
We should possibly move the previous/next flex `div` into a `const function` of its own.
Thoughts? 

This is a really exciting project. I really like the ideology and would like to contribute however possible.

Thanks

