### PR TITLE
Stick footer to bottom

### DIFF
--- a/src/components/layout.css
+++ b/src/components/layout.css
@@ -102,3 +102,19 @@ h3 {
 @tailwind components;
 
 @tailwind utilities;
+
+html,
+body,
+#___gatsby,
+#gatsby-focus-wrapper  {
+  height: 100%;
+}
+
+ #gatsby-focus-wrapper {
+  display: flex;
+  flex-direction: column;
+}
+
+main {
+  flex: auto;
+}

--- a/src/components/layout.css
+++ b/src/components/layout.css
@@ -103,6 +103,7 @@ h3 {
 
 @tailwind utilities;
 
+/* Ensure Footer always sticks to the bottom */
 html,
 body,
 #___gatsby,


### PR DESCRIPTION
Fix #5 
The footer now sticks to the bottom.
![Screenshot from 2019-11-19 17-19-54](https://user-images.githubusercontent.com/22499864/69144315-05dd3280-0af1-11ea-9545-b521a76a31a8.png)
