### PR TITLE
Fix #30: Add basic Github Actions config file 

### DIFF
--- a/.github/workflows/nodejs.yml
+++ b/.github/workflows/nodejs.yml
@@ -1,0 +1,26 @@
+name: Node CI
+
+on: [push, pull_request]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    strategy:
+      matrix:
+        node-version: [8.x, 10.x, 12.x]
+
+    steps:
+    - uses: actions/checkout@v1
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v1
+      with:
+        node-version: ${{ matrix.node-version }}
+    - name: yarn install and test
+      run: |
+        
+        yarn install
+        yarn lint
+      env:
+        CI: true


### PR DESCRIPTION
This PR adds a github actions nodejs.yml file which does two things when a push or pull request is made to the repo:
1. Install all dependencies using `yarn install`
2. Run a linter, in this case eslint. 

There is a lot that can be done now that we have this file. We can add some tests for our code and then run a test suite. 
We can add another such yml file that will deploy code to Github pages (see #7 ) whenever a push is made to the master. For this, we can either use an action like jamesIves/github-pages-deploy-action@master or just run the following in a new deploy.yml file:
```gatsby build && gh-pages -d public -b master -r https://github.com/openclimatefix/openclimatefix.github.io -a```