### PR TITLE
Add dedicated Get Involved Page

### DIFF
--- a/src/components/ContributorShowcase/ContributorShowcase.jsx
+++ b/src/components/ContributorShowcase/ContributorShowcase.jsx
@@ -19,6 +19,7 @@ function ContributorShowcase() {
   return (
     <>
       <h2>Contributors</h2>
+      <p>Join our amazing group of contributors and get involved.<br/>These people are already contributing to our work.</p>
       <StaticQuery
         query={graphql`
           query queryJSON {

--- a/src/components/ContributorShowcase/ContributorShowcase.jsx
+++ b/src/components/ContributorShowcase/ContributorShowcase.jsx
@@ -6,10 +6,10 @@ function renderContributorsFromData(data) {
   const cont = [];
   data.contributorsJson.contributors.forEach((item) => {
     cont.push(
-      <div className={styles.griditem} key={item.profile}>
-        <img className={styles.image} alt={item.profile} src={item.avatar_url} />
-        <a href={item.profile}>{item.name}</a>
-      </div>,
+    <div className={styles.griditem} key={item.profile}>
+      <img className={styles.image} alt={item.profile} src={item.avatar_url} />
+      <a href={item.profile}>{item.name}</a>
+    </div>,
     );
   });
   return cont;
@@ -19,7 +19,10 @@ function ContributorShowcase() {
   return (
     <>
       <h2>Contributors</h2>
-      <p>Join our amazing group of contributors and get involved.<br/>These people are already contributing to our work.</p>
+      <p>Join our amazing group of contributors and get involved.
+        <br />
+        These people are already contributing to our work.
+      </p>
       <StaticQuery
         query={graphql`
           query queryJSON {

--- a/src/components/ContributorShowcase/ContributorShowcase.jsx
+++ b/src/components/ContributorShowcase/ContributorShowcase.jsx
@@ -7,8 +7,8 @@ function renderContributorsFromData(data) {
   data.contributorsJson.contributors.forEach((item) => {
     cont.push(
       <div className={styles.griditem} key={item.profile}>
-      <img className={styles.image} alt={item.profile} src={item.avatar_url} />
-      <a href={item.profile}>{item.name}</a>
+        <img className={styles.image} alt={item.profile} src={item.avatar_url} />
+        <a href={item.profile}>{item.name}</a>
       </div>,
     );
   });

--- a/src/components/ContributorShowcase/ContributorShowcase.jsx
+++ b/src/components/ContributorShowcase/ContributorShowcase.jsx
@@ -6,10 +6,10 @@ function renderContributorsFromData(data) {
   const cont = [];
   data.contributorsJson.contributors.forEach((item) => {
     cont.push(
-    <div className={styles.griditem} key={item.profile}>
+      <div className={styles.griditem} key={item.profile}>
       <img className={styles.image} alt={item.profile} src={item.avatar_url} />
       <a href={item.profile}>{item.name}</a>
-    </div>,
+      </div>,
     );
   });
   return cont;
@@ -19,7 +19,8 @@ function ContributorShowcase() {
   return (
     <>
       <h2>Contributors</h2>
-      <p>Join our amazing group of contributors and get involved.
+      <p>
+        Join our amazing group of contributors and get involved.
         <br />
         These people are already contributing to our work.
       </p>

--- a/src/components/ContributorShowcase/ContributorShowcase.module.css
+++ b/src/components/ContributorShowcase/ContributorShowcase.module.css
@@ -37,5 +37,6 @@
 
 .griditem {
   padding: 10px;
+  @apply text-blue-600;
   @apply text-xs text-center;
 }

--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -86,7 +86,7 @@ class Header extends Component {
             </div>
             <div>
               <Link
-                to="/#get-involved"
+                to="/get-involved"
                 className="inline-block text-sm px-4 py-2 leading-none border rounded text-white border-white hover:border-transparent hover:text-black hover:bg-white mt-4 lg:mt-0"
               >
                 Get Involved

--- a/src/pages/get-involved.jsx
+++ b/src/pages/get-involved.jsx
@@ -6,7 +6,7 @@ const getInvolvedPage = () => (
   <Layout>
     <h1>Get Involved</h1>
     <div className="markdown">
-        <ul>
+      <ul>
         <li>
           <a href="https://opencollective.com/openclimatefix">Donate</a>
           {' '}
@@ -22,7 +22,7 @@ const getInvolvedPage = () => (
           {' '}
           <a href="https://openclimatefix.discourse.group/">OCF discussion forum</a>
         </li>
-        </ul>
+      </ul>
       <p>
         Also check out
         {' '}

--- a/src/pages/get-involved.jsx
+++ b/src/pages/get-involved.jsx
@@ -6,7 +6,7 @@ const getInvolvedPage = () => (
   <Layout>
     <h1>Get Involved</h1>
     <div className="markdown">
-      <ul>
+        <ul>
         <li>
           <a href="https://opencollective.com/openclimatefix">Donate</a>
           {' '}
@@ -22,7 +22,7 @@ const getInvolvedPage = () => (
           {' '}
           <a href="https://openclimatefix.discourse.group/">OCF discussion forum</a>
         </li>
-      </ul>
+        </ul>
       <p>
         Also check out
         {' '}
@@ -33,7 +33,8 @@ const getInvolvedPage = () => (
       </p>
       <h2>Contribute to one of our repositories on Github</h2>
       <p>
-        Check out our 
+        Check out our
+        {' '}
         <a href="https://github.com/search?l=&p=1&q=user%3Aopenclimatefix+label%3A%22good+first+issue%22&ref=advsearch&type=Issues&utf8=%E2%9C%93&state=open">List of Good First Issues</a>
         to get started!
       </p>

--- a/src/pages/get-involved.jsx
+++ b/src/pages/get-involved.jsx
@@ -6,7 +6,7 @@ const getInvolvedPage = () => (
   <Layout>
     <h1>Get Involved</h1>
     <div className="markdown">
-    <p>Space for FWirtz</p>
+    <p></p>
         <ul>
           <li>
             <a href="https://opencollective.com/openclimatefix">Donate</a>

--- a/src/pages/get-involved.jsx
+++ b/src/pages/get-involved.jsx
@@ -1,0 +1,42 @@
+import React from 'react';
+import Layout from '../components/Layout';
+import ContributorShowcase from '../components/ContributorShowcase';
+
+const getInvolvedPage = () => (
+  <Layout>
+    <h1>Get Involved</h1>
+    <div className="markdown">
+    <p>Space for FWirtz</p>
+        <ul>
+          <li>
+            <a href="https://opencollective.com/openclimatefix">Donate</a>
+            {' '}
+            to our OpenCollective
+          </li>
+          <li>
+            Follow us by
+            {' '}
+            <a href="https://eepurl.com/guCjvH">signing up to our newsletter</a>
+          </li>
+          <li>
+            Join the
+            {' '}
+            <a href="https://openclimatefix.discourse.group/">OCF discussion forum</a>
+          </li>
+        </ul>
+        <p>
+          Also check out
+          {' '}
+          <a href="/blog/2019-03-06-how-to-get-involved">
+            Jack&apos;s blog post about getting involved
+          </a>
+          .
+        </p>
+        <h2>Contribute to one of our repositories on Github</h2>
+        <p>Check out our <a href="https://github.com/search?l=&p=1&q=user%3Aopenclimatefix+label%3A%22good+first+issue%22&ref=advsearch&type=Issues&utf8=%E2%9C%93&state=open">List of Good First Issues</a> to get started!</p>
+        <ContributorShowcase />
+      </div>
+  </Layout>
+);
+
+export default getInvolvedPage;

--- a/src/pages/get-involved.jsx
+++ b/src/pages/get-involved.jsx
@@ -36,6 +36,7 @@ const getInvolvedPage = () => (
         Check out our
         {' '}
         <a href="https://github.com/search?l=&p=1&q=user%3Aopenclimatefix+label%3A%22good+first+issue%22&ref=advsearch&type=Issues&utf8=%E2%9C%93&state=open">List of Good First Issues</a>
+        {' '}
         to get started!
       </p>
       <ContributorShowcase />

--- a/src/pages/get-involved.jsx
+++ b/src/pages/get-involved.jsx
@@ -8,31 +8,32 @@ const getInvolvedPage = () => (
     <div className="markdown">
       <ul>
         <li>
-            <a href="https://opencollective.com/openclimatefix">Donate</a>
-            {' '}
-            to our OpenCollective
-          </li>
-          <li>
-            Follow us by
-            {' '}
-            <a href="https://eepurl.com/guCjvH">signing up to our newsletter</a>
-          </li>
-          <li>
-            Join the
-            {' '}
-            <a href="https://openclimatefix.discourse.group/">OCF discussion forum</a>
-          </li>
-        </ul>
-        <p>
-          Also check out
+          <a href="https://opencollective.com/openclimatefix">Donate</a>
           {' '}
-          <a href="/blog/2019-03-06-how-to-get-involved">
-            Jack&apos;s blog post about getting involved
-          </a>
-          .
-        </p>
+          to our OpenCollective
+        </li>
+        <li>
+          Follow us by
+          {' '}
+          <a href="https://eepurl.com/guCjvH">signing up to our newsletter</a>
+        </li>
+        <li>
+          Join the
+          {' '}
+          <a href="https://openclimatefix.discourse.group/">OCF discussion forum</a>
+        </li>
+      </ul>
+      <p>
+        Also check out
+        {' '}
+        <a href="/blog/2019-03-06-how-to-get-involved">
+          Jack&apos;s blog post about getting involved
+        </a>
+        .
+      </p>
       <h2>Contribute to one of our repositories on Github</h2>
-      <p>Check out our 
+      <p>
+        Check out our 
         <a href="https://github.com/search?l=&p=1&q=user%3Aopenclimatefix+label%3A%22good+first+issue%22&ref=advsearch&type=Issues&utf8=%E2%9C%93&state=open">List of Good First Issues</a>
         to get started!
       </p>

--- a/src/pages/get-involved.jsx
+++ b/src/pages/get-involved.jsx
@@ -6,9 +6,8 @@ const getInvolvedPage = () => (
   <Layout>
     <h1>Get Involved</h1>
     <div className="markdown">
-    <p></p>
-        <ul>
-          <li>
+      <ul>
+        <li>
             <a href="https://opencollective.com/openclimatefix">Donate</a>
             {' '}
             to our OpenCollective
@@ -32,10 +31,13 @@ const getInvolvedPage = () => (
           </a>
           .
         </p>
-        <h2>Contribute to one of our repositories on Github</h2>
-        <p>Check out our <a href="https://github.com/search?l=&p=1&q=user%3Aopenclimatefix+label%3A%22good+first+issue%22&ref=advsearch&type=Issues&utf8=%E2%9C%93&state=open">List of Good First Issues</a> to get started!</p>
-        <ContributorShowcase />
-      </div>
+      <h2>Contribute to one of our repositories on Github</h2>
+      <p>Check out our 
+        <a href="https://github.com/search?l=&p=1&q=user%3Aopenclimatefix+label%3A%22good+first+issue%22&ref=advsearch&type=Issues&utf8=%E2%9C%93&state=open">List of Good First Issues</a>
+        to get started!
+      </p>
+      <ContributorShowcase />
+    </div>
   </Layout>
 );
 

--- a/src/pages/index.jsx
+++ b/src/pages/index.jsx
@@ -95,36 +95,6 @@ const IndexPage = () => (
           </a>
         </p>
       </div>
-
-      <h2 id="get-involved" className="mt-16 mb-2">Get Involved</h2>
-      <div className="markdown">
-        <ul>
-          <li>
-            <a href="https://opencollective.com/openclimatefix">Donate</a>
-            {' '}
-            to our OpenCollective
-          </li>
-          <li>
-            Follow us by
-            {' '}
-            <a href="https://eepurl.com/guCjvH">signing up to our newsletter</a>
-          </li>
-          <li>
-            Join the
-            {' '}
-            <a href="https://openclimatefix.discourse.group/">OCF discussion forum</a>
-          </li>
-        </ul>
-        <p>
-          Also check out
-          {' '}
-          <a href="/blog/2019-03-06-how-to-get-involved">
-            Jack&apos;s blog post about getting involved
-          </a>
-          .
-        </p>
-        <ContributorShowcase />
-      </div>
       <h2 id="funding" className="mt-16 mb-2">Funding</h2>
       <div className="markdown">
         <p>


### PR DESCRIPTION
I have added the Get Involved Page by creating a new page, migrating the get involved section for the main page, and linking the new page to the Get Involved button. The new page also contains the Contributor Showcase component, which I modified to fit the mockup better. Finally, I have added a link to good first open issues, and a space for anything OpenClimateFix wants to say to potential contributors.

Fixes #3.