### PR TITLE
Add ARIA attributes to header navigation menu

### DIFF
--- a/src/components/Header.jsx
+++ b/src/components/Header.jsx
@@ -46,6 +46,8 @@ class Header extends Component {
           </Link>
           <div className="block lg:hidden">
             <button
+              aria-expanded={!menuClosed}
+              aria-labelledby="header--nav-menu"
               type="button"
               onClick={() => this.toggleMenu()}
               className="flex items-center px-3 py-2 border rounded text-white border-white hover:text-white hover:border-white"
@@ -55,7 +57,7 @@ class Header extends Component {
                 viewBox="0 0 20 20"
                 xmlns="http://www.w3.org/2000/svg"
               >
-                <title>Menu</title>
+                <title id="header--nav-menu">Menu</title>
                 <path d="M0 3h20v2H0V3zm0 6h20v2H0V9zm0 6h20v2H0v-2z" />
               </svg>
             </button>


### PR DESCRIPTION
Add ARIA attributes to header navigation menu to improve accessibility by labeling the menu button and indicating when the button is in the pressed state.

Resolves #36