### PR TITLE
⚓ Extend SEO component to pass relevant props from blog post

### DIFF
--- a/src/components/BlogPost/BlogPost.jsx
+++ b/src/components/BlogPost/BlogPost.jsx
@@ -34,7 +34,7 @@ export default function BlogPost({
   return (
     <Layout>
       <SEO
-        title={`Blog: ${title}`}
+        title={title}
         imageUrl={coverImageUrl}
         description={excerpt}
         authorTwitter={authorTwitter}

--- a/src/components/BlogPost/BlogPost.jsx
+++ b/src/components/BlogPost/BlogPost.jsx
@@ -16,7 +16,7 @@ export default function BlogPost({
 }) {
   const { prev, next } = pageContext;
   const {
-    markdownRemark: { frontmatter, html },
+    markdownRemark: { frontmatter, excerpt, html },
   } = data;
   const {
     authorName,
@@ -29,9 +29,16 @@ export default function BlogPost({
     coverImagePhotographerName,
   } = frontmatter;
 
+  const coverImageUrl = `https://source.unsplash.com/${coverImageUnsplashId}/624x384`;
+
   return (
     <Layout>
-      <SEO title={`Blog: ${title}`} />
+      <SEO
+        title={`Blog: ${title}`}
+        imageUrl={coverImageUrl}
+        description={excerpt}
+        authorTwitter={authorTwitter}
+      />
       <article className="">
         <h1>{title}</h1>
         <AuthorDateBlock
@@ -44,7 +51,7 @@ export default function BlogPost({
           <img
             style={{ maxHeight: '24rem' }}
             className="object-cover w-full"
-            src={`https://source.unsplash.com/${coverImageUnsplashId}/624x384`}
+            src={coverImageUrl}
             alt="Blog Post Cover Image"
           />
           <figcaption className="text-xs text-gray-600 text-center mt-1">
@@ -76,6 +83,7 @@ export const pageQuery = graphql`
   query($path: String!) {
     markdownRemark(frontmatter: { path: { eq: $path } }) {
       html
+      excerpt(pruneLength: 160)
       frontmatter {
         date(formatString: "MMMM DD, YYYY")
         path
@@ -94,6 +102,7 @@ BlogPost.propTypes = {
   data: PropTypes.shape({
     markdownRemark: PropTypes.shape({
       html: PropTypes.string.isRequired,
+      excerpt: PropTypes.string.isRequired,
       frontmatter: PropTypes.shape({
         date: PropTypes.string.isRequired,
         path: PropTypes.string.isRequired,

--- a/src/components/seo.jsx
+++ b/src/components/seo.jsx
@@ -1,9 +1,9 @@
 import React from 'react';
 import PropTypes from 'prop-types';
-import {Helmet} from 'react-helmet';
+import { Helmet } from 'react-helmet';
 import { useStaticQuery, graphql } from 'gatsby';
 
-function SEO({ description, lang, meta, title }) {
+function SEO({ description, lang, meta, title, imageUrl, authorTwitter }) {
   const { site } = useStaticQuery(
     graphql`
       query {
@@ -19,6 +19,14 @@ function SEO({ description, lang, meta, title }) {
   );
 
   const metaDescription = description || site.siteMetadata.description;
+  const metaImageUrl =
+    imageUrl ||
+    'https://raw.githubusercontent.com/openclimatefix/website/master/src/images/logo_dark_square%402x.png';
+
+  // Note: this assumes that authorTwitter does not include @
+  const metaAuthorTwitter = authorTwitter
+    ? `@${authorTwitter}`
+    : site.siteMetadata.author;
 
   return (
     <Helmet
@@ -29,9 +37,9 @@ function SEO({ description, lang, meta, title }) {
       titleTemplate={`%s | ${site.siteMetadata.title}`}
       link={[
         {
-          href: "https://fonts.googleapis.com/css2?family=Inter&display=swap",
-          rel: "stylesheet"
-        }
+          href: 'https://fonts.googleapis.com/css2?family=Inter&display=swap',
+          rel: 'stylesheet',
+        },
       ]}
       meta={[
         {
@@ -52,8 +60,7 @@ function SEO({ description, lang, meta, title }) {
         },
         {
           property: 'og:image',
-          content:
-            'https://raw.githubusercontent.com/openclimatefix/website/master/src/images/logo_dark_square%402x.png',
+          content: metaImageUrl,
         },
         {
           name: 'twitter:card',
@@ -61,7 +68,7 @@ function SEO({ description, lang, meta, title }) {
         },
         {
           name: 'twitter:creator',
-          content: site.siteMetadata.author,
+          content: metaAuthorTwitter,
         },
         {
           name: 'twitter:title',
@@ -73,8 +80,7 @@ function SEO({ description, lang, meta, title }) {
         },
         {
           name: 'twitter:image',
-          content:
-            'https://raw.githubusercontent.com/openclimatefix/website/master/src/images/logo_dark_square%402x.png',
+          content: metaImageUrl,
         },
         {
           name: 'twitter:site',


### PR DESCRIPTION
Fixes #63

- Adds `imageUrl` and `authorTwitter` to SEO component props
- Adds `excerpt` to blog post query. Since there is no "description" field in the blog post md files, the excerpt uses the first 160 characters of the post