### PR TITLE
🎬 Purge unused tailwind css

### DIFF
--- a/tailwind.config.js
+++ b/tailwind.config.js
@@ -1,4 +1,5 @@
 module.exports = {
+  purge: ['./src/**/*.jsx', './src/**/*.js'],
   theme: {
     extend: {},
   },


### PR DESCRIPTION
Adds jsx and js files to tailwind `purge` config. This will mean that on build, gatsby/tailwind will discover which css is being used, and not include unused css in the compiled html files.

Fixes #79