### PR TITLE
Add blog post filter by project

### DIFF
--- a/src/components/PostFilters.jsx
+++ b/src/components/PostFilters.jsx
@@ -1,0 +1,28 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+
+const PostFilters = ({ options, selected, setSelected }) => (
+  <div className="mb-4">
+    {[undefined, ...options].map((option) => (
+      <button
+        className={`mr-2 my-1 text-sm py-0 px-2 border border-black-500 rounded 
+          ${
+            selected === option
+              ? 'bg-gray-500 text-white hover:text-black hover:bg-transparent'
+              : 'bg-transparent text-black hover:text-white hover:bg-gray-500'
+          }`}
+        onClick={() => setSelected(option)}
+      >
+        {!option ? 'all posts' : option}
+      </button>
+    ))}
+  </div>
+);
+
+PostFilters.propTypes = {
+  options: PropTypes.arrayOf(PropTypes.string).isRequired,
+  selected: PropTypes.string,
+  setSelected: PropTypes.func.isRequired,
+};
+
+export default PostFilters;

--- a/src/components/PostList.jsx
+++ b/src/components/PostList.jsx
@@ -1,23 +1,50 @@
-import React from 'react';
+import React, { useMemo, useState } from 'react';
 import PropTypes from 'prop-types';
 
 import PostLink from './PostLink';
+import PostFilters from './PostFilters';
 
-const PostList = ({ posts }) => (
-  <div className="mt-6">
-    <ul>
-      {posts.map(({ node: post }) => (
-        <PostLink key={post.id} post={post} />
-      ))}
-    </ul>
-  </div>
-);
+const PostList = ({ posts }) => {
+  const [projectFilter, setProjectFilter] = useState();
+
+  const projects = useMemo(
+    () =>
+      posts.reduce((acc, { node: post }) => {
+        const { project } = post.frontmatter;
+        return !!project && !acc.includes(project) ? [...acc, project] : acc;
+      }, []),
+    [posts]
+  );
+
+  return (
+    <div className="mt-6">
+      <PostFilters
+        options={projects}
+        selected={projectFilter}
+        setSelected={setProjectFilter}
+      />
+      <ul>
+        {posts
+          .filter(
+            ({ node: post }) =>
+              !projectFilter || projectFilter === post.frontmatter.project
+          )
+          .map(({ node: post }) => (
+            <PostLink key={post.id} post={post} />
+          ))}
+      </ul>
+    </div>
+  );
+};
 
 PostList.propTypes = {
   posts: PropTypes.arrayOf(
     PropTypes.shape({
       node: PropTypes.shape({
         id: PropTypes.string.isRequired,
+        frontmatter: {
+          project: PropTypes.string,
+        },
       }).isRequired,
     }).isRequired
   ).isRequired,

--- a/src/pages/blog.jsx
+++ b/src/pages/blog.jsx
@@ -55,6 +55,7 @@ export const pageQuery = graphql`
             authorName
             authorImage
             coverImageUnsplashId
+            project
           }
           fields {
             readingTime {


### PR DESCRIPTION
#62 
This adds a row of buttons that map to the `project` field of blog posts.
The buttons function with a radio-button style of UX, where clicking a new one deselects the old one.
A button for `all posts` is also added, and is active prior to any interaction.

before | after
---|---
<img width="671" alt="Screenshot 2021-05-21 at 10 57 19" src="https://user-images.githubusercontent.com/23401306/119111463-ff4bb600-ba1a-11eb-93ad-d01b23ee72bd.png">|<img width="677" alt="Screenshot 2021-05-21 at 10 57 11" src="https://user-images.githubusercontent.com/23401306/119111498-0672c400-ba1b-11eb-8dd7-f855b798af04.png">

